### PR TITLE
Added missing input name

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -102,7 +102,7 @@ const IndexPage = () => {
                   id="username"
                   name="username"
                   className="text-input"
-                  ref={register({
+                  ref={register( "username", {
                     required: { message: "Please enter", value: true },
                     minLength: { message: "Minimum length 3", value: 3 },
                   })}


### PR DESCRIPTION
The missing first argument, results in a `t.split is not a function` error.